### PR TITLE
fixed bug in notification box

### DIFF
--- a/frontend/src/components/NotificationBox/NotificationBox.js
+++ b/frontend/src/components/NotificationBox/NotificationBox.js
@@ -16,8 +16,9 @@ function NotificationBox() {
         axios.post(`/notification/${id}/delete`)
             .then(() => {
                 console.log('Notification deleted!');
-                setNotifications(notifications.filter(element => element._id !== id));
-                setEmptyMessage(true);
+                const list = notifications.filter(element => element._id !== id);
+                setNotifications(list);
+                if (list.length === 0) setEmptyMessage(true);
             })
             .catch((err) => {
                 console.log(err);


### PR DESCRIPTION
# General info

**Task description**: 

 - Fixed bug where "No notifications" message was displayed when a single notification was deleted

# Testing

**Test coverage**:
- Tested manually

# Additional notes

**Note to reviewers**:
- Delete notifications
- The "No notifications" message should be displayed only when all notifications have been deleted

**To do before merging**:
- [ ] Edit Changelog(if necessary)